### PR TITLE
Cosign/podman/ci updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ env:
   # renovate: datasource=go depName=mvdan.cc/gofumpt
   GOFUMPT_VERSION: v0.3.1
   # renovate: datasource=go depName=github.com/golangci/golangci-lint
-  GOLANGCI_LINT_VERSION: v1.53.3
+  GOLANGCI_LINT_VERSION: v1.54.2
 
 jobs:
   skip-check:

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -53,6 +53,12 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
 
+      - name: 'Trust the github workspace'
+        run: |
+          # This is to avoid fatal errors about "dubious ownership" because we are
+          # running inside of a container action with the workspace mounted in.
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Set up Go
         uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a # tag=v3.2.1
         with:
@@ -76,7 +82,7 @@ jobs:
     needs: build-binaries
     runs-on: ubuntu-latest
     container:
-      image: quay.io/containers/podman:v4.6.2@sha256:e0cef628e369cf466979d08bda2c25d861e2b90e6236e99b817235b612c511b3
+      image: quay.io/containers/podman:v4.6.2@sha256:0402e08323ce9f033c710a05913e9258f1d9c59af76930580adb2ec8a1f68db6
       options: >-
         --device /dev/fuse:rw
         --privileged

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -44,7 +44,7 @@ jobs:
     if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: docker.io/goreleaser/goreleaser-cross:v1.18.3
+      image: docker.io/goreleaser/goreleaser-cross:v1.21.1
       options: --privileged
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   # renovate: datasource=go depName=github.com/goreleaser/goreleaser
-  GORELEASER_VERSION: v1.10.2
+  GORELEASER_VERSION: v1.21.2
 
 jobs:
   skip-check:

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -60,7 +60,7 @@ jobs:
           cache: true
 
       - name: Run Goreleaser
-        run: goreleaser release --rm-dist --skip-validate --skip-publish --snapshot --debug
+        run: goreleaser release --clean --skip-validate --skip-publish --snapshot --debug
 
       - name: Archive generated artifacts
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # tag=v3.1.0

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -82,6 +82,8 @@ jobs:
         --privileged
         --security-opt label=disable
         --security-opt seccomp=unconfined
+      env:
+        TUF_ROOT: /tmp
     permissions:
       id-token: write
       packages: write
@@ -127,7 +129,7 @@ jobs:
 
       - name: Push and sign container
         env:
-          COSIGN_EXPERIMENTAL: true
+          COSIGN_YES: true
         run: |
           make push-container
           make sign-container

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,6 @@ name: Documents
 on:
   push:
     branches: [ main ]
-    paths:
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: binaries
     container:
-      image: quay.io/containers/podman:v4.6.2@sha256:e0cef628e369cf466979d08bda2c25d861e2b90e6236e99b817235b612c511b3
+      image: quay.io/containers/podman:v4.6.2@sha256:0402e08323ce9f033c710a05913e9258f1d9c59af76930580adb2ec8a1f68db6
       options: >-
         --device /dev/fuse:rw
         --privileged

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   # renovate: datasource=go depName=github.com/goreleaser/goreleaser
-  GORELEASER_VERSION: v1.18.2
+  GORELEASER_VERSION: v1.21.2
 
 jobs:
   binaries:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,8 @@ jobs:
         --privileged
         --security-opt label=disable
         --security-opt seccomp=unconfined
+      env:
+        TUF_ROOT: /tmp
     permissions:
       id-token: write
       packages: write
@@ -116,6 +118,6 @@ jobs:
 
       - name: Sign container
         env:
-          COSIGN_EXPERIMENTAL: true
+          COSIGN_YES: true
         run: |
           make sign-container

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,13 +28,14 @@ builds:
       # {{.CommitDate}} is the date of the commit to make builds reproducible.
       - -X main.version={{.Version}} -X main.commit={{.FullCommit}} -X main.date={{.CommitDate}} -X main.goArch={{.Runtime.Goarch}}
 archives:
-  - replacements:
-      linux: Linux
-      darwin: Darwin
-      amd64: x86_64
-    format_overrides:
-      - goos: windows
-        format: zip
+  - id: archives
+    name_template: >-
+      {{- .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end -}}
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ container: $(OUT_DIR)
 
 .PHONY: container-dev
 container-dev:
-	docker build -t $(OUT_DOCKER_DEV):$(VERSION) --build-arg=GOLANG_BASE=golang:1.18.3-bullseye --build-arg=DEBIAN_BASE=debian:bullseye-slim .
+	docker build -t $(OUT_DOCKER_DEV):$(VERSION) --build-arg=GOLANG_BASE=golang:1.21.1-bullseye --build-arg=DEBIAN_BASE=debian:bullseye-slim .
 
 .PHONY: sign-container
 sign-container:

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ container-dev:
 .PHONY: sign-container
 sign-container:
 	crane digest $(OUT_DOCKER):$(VERSION)
-	cosign sign --force -a GIT_HASH=$(COMMIT) -a GIT_VERSION=$(VERSION) $(OUT_DOCKER)@$(shell crane digest $(OUT_DOCKER):$(VERSION))
+	cosign sign -a GIT_HASH=$(COMMIT) -a GIT_VERSION=$(VERSION) $(OUT_DOCKER)@$(shell crane digest $(OUT_DOCKER):$(VERSION))
 
 .PHONY: push-container
 push-container:


### PR DESCRIPTION
- update goreleaser version
- update golangci-lint
- update goreleaser flag
- update go image to match the go modules
- update cosign flags
- update deprecated section
- update podman digest


rehearsal: https://github.com/cpanato/profile-exporter/actions/runs/6329208008

container push job: https://github.com/cpanato/profile-exporter/actions/runs/6329201658 